### PR TITLE
Add a placeholder for HAVE_INITGROUPS, so that the value gets set properl

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -103,6 +103,9 @@
 /* Define if you have the strerror() function. */
 #undef HAVE_STRERROR
 
+/* Define if you have initgroups() */
+#undef HAVE_INITGROUPS
+
 /* Define if you have vfork() */
 #undef HAVE_VFORK
 


### PR DESCRIPTION
Add a placeholder for HAVE_INITGROUPS, so that the value gets set properly
by configure.
