### PR TITLE
Don't assume malloc() allocations are pre-initialized

### DIFF
--- a/daemonize.c
+++ b/daemonize.c
@@ -147,6 +147,13 @@ static void add_to_env(char opt, const char *envvar)
 
     char *name = (char *) malloc(name_len + 1);
     char *value = (char *) malloc(val_len + 1);
+
+    if (name == NULL || value == NULL)
+        die("Cannot allocate memory for \"%s\" variable/value pair: %s\n",
+            envvar, strerror (errno));
+
+    *name = *value = '\0';
+
     (void) strncat(name, envvar, name_len);
     eq++;
     (void) strncat(value, eq, val_len);


### PR DESCRIPTION
The `add_to_env()` function in `daemonize.c` makes the unsafe assumption that memory allocated via `malloc()` will be at least partially zero-filled. This is most definitely **not the case** for many (_most?_) libc/heap allocators.

If the first byte of each allocation is not 0, the following `strncat()`calls will skip over the initial bytes from until they discover the terminating asciiz null which represents the starting point of concatenation. While this likely does not represent a true buffer overrun because of the total concatenation limitation of `strncat` (assuming one has a non-buggy implementation of couse) it *is* the case that this **will** result in corrupted environment variables on many systems should daemonize's `-E` optarg be subjected to heavy use.

This PR null-terminates each allocation prior to calling `strncat()`.

Additionally, I added a check for `malloc()` failures of these specific allocations, although this is more a result of sheer force of habit and endorsement of best practices than due to an actual experienced problem (given that it is highly unlikely that such early and small allocations would actually fail).