### PR TITLE
fix getopt.c too many arguments to function 'write' error in gcc-15.0.1

### DIFF
--- a/getopt.c
+++ b/getopt.c
@@ -45,7 +45,7 @@
 #include <string.h>
 
 #define ERR(s, c)	if(x_opterr){\
-	extern int write();\
+	extern int write(int, const void *, unsigned);\
 	char errbuf[2];\
 	errbuf[0] = c; errbuf[1] = '\n';\
 	(void) write(2, argv[0], (unsigned)strlen(argv[0]));\


### PR DESCRIPTION
In the original code, write() was declared as 'extern int write();', which is interpreted as a function taking no parameters. This caused errors when actually calling it with 3 parameters. The current fix to declare it as 'extern int write(int, const void *, unsigned);' is the correct solution.
This properly defines the write function to accept 3 parameters.

../git/getopt.c: In function 'x_getopt':
../git/getopt.c:51:16: error: too many arguments to function 'write'; expected 0, have 3
   51 |         (void) write(2, argv[0], (unsigned)strlen(argv[0]));\
      |                ^~~~~ ~
../git/getopt.c:78:17: note: in expansion of macro 'ERR'
   78 |                 ERR(": illegal option -- ", c);
      |                 ^~~
../git/getopt.c:48:20: note: declared here
   48 |         extern int write();\
      |                    ^~~~~