### PR TITLE
Use #include <unistd.h> for obtaining the prototype of write()

### DIFF
--- a/getopt.c
+++ b/getopt.c
@@ -43,9 +43,9 @@
 #include <stdio.h>
 /* We're ANSI now; we're guaranteed to have strchr(). */
 #include <string.h>
+#include <unistd.h>
 
 #define ERR(s, c)	if(x_opterr){\
-	extern int write(int, const void *, unsigned);\
 	char errbuf[2];\
 	errbuf[0] = c; errbuf[1] = '\n';\
 	(void) write(2, argv[0], (unsigned)strlen(argv[0]));\


### PR DESCRIPTION
Commit 5823762 did
```
-	extern int write();\
+	extern int write(int, const void *, unsigned);\
```
but the actual function signature is
```
ssize_t write (int, const void *, size_t);
```

The 80s are over, just include the header for the prototype.

@bmc @markyang92 